### PR TITLE
Zxzinn/spa 26 impl file management

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -29,9 +29,6 @@
       "recommended": true,
       "suspicious": {
         "noUnknownAtRules": "off"
-      },
-      "a11y": {
-        "noStaticElementInteractions": "off"
       }
     },
     "domains": {

--- a/biome.json
+++ b/biome.json
@@ -29,6 +29,9 @@
       "recommended": true,
       "suspicious": {
         "noUnknownAtRules": "off"
+      },
+      "a11y": {
+        "noStaticElementInteractions": "off"
       }
     },
     "domains": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@ai-sdk/google": "^2.0.17",
         "@ai-sdk/perplexity": "^2.0.11",
         "@ai-sdk/react": "^2.0.56",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/utilities": "^3.2.2",
         "@prisma/client": "^6.16.3",
         "@prisma/extension-accelerate": "^2.0.2",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -62,7 +64,6 @@
         "husky": "^9.1.7",
         "jsdom": "^27.0.0",
         "lint-staged": "^16.2.3",
-        "supabase": "^2.48.3",
         "tailwindcss": "^4",
         "tsx": "^4.20.6",
         "turbo": "^2.5.8",
@@ -984,6 +985,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -4943,23 +4983,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/bin-links": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-5.0.0.tgz",
-      "integrity": "sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cmd-shim": "^7.0.0",
-        "npm-normalize-package-bin": "^4.0.0",
-        "proc-log": "^5.0.0",
-        "read-cmd-shim": "^5.0.0",
-        "write-file-atomic": "^6.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -5387,16 +5410,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/cmd-shim": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-7.0.0.tgz",
-      "integrity": "sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/colorette": {
@@ -6034,16 +6047,6 @@
       "dependencies": {
         "d3": "^7.9.0",
         "lodash-es": "^4.17.21"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/data-urls": {
@@ -6698,30 +6701,6 @@
         }
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -6777,19 +6756,6 @@
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -7723,16 +7689,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -9820,27 +9776,6 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -9907,16 +9842,6 @@
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/npm-normalize-package-bin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
-      "integrity": "sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/nypm": {
       "version": "0.6.2",
@@ -10225,16 +10150,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/proc-log": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
-      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/property-information": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
@@ -10465,16 +10380,6 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/read-cmd-shim": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-5.0.0.tgz",
-      "integrity": "sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/readdirp": {
@@ -11210,45 +11115,6 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
-    },
-    "node_modules/supabase": {
-      "version": "2.48.3",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.48.3.tgz",
-      "integrity": "sha512-92vjrWqRUQPX9eYgTYlSSVXfpjzsAa++IX7IEM99BoYvNS3Pl6VrsqGN06QWi4VaX7FlPjjHLp+aIjoeWXcBug==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bin-links": "^5.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "node-fetch": "^3.3.2",
-        "tar": "7.5.1"
-      },
-      "bin": {
-        "supabase": "bin/supabase"
-      },
-      "engines": {
-        "npm": ">=8"
-      }
-    },
-    "node_modules/supabase/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/swr": {
       "version": "2.3.6",
@@ -12238,16 +12104,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/web-tree-sitter": {
       "version": "0.24.7",
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.7.tgz",
@@ -12366,20 +12222,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/write-file-atomic": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
-      "integrity": "sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@ai-sdk/google": "^2.0.17",
     "@ai-sdk/perplexity": "^2.0.11",
     "@ai-sdk/react": "^2.0.56",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@prisma/client": "^6.16.3",
     "@prisma/extension-accelerate": "^2.0.2",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/src/app/api/documents/[documentId]/file/[fileName]/route.test.ts
+++ b/src/app/api/documents/[documentId]/file/[fileName]/route.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DELETE } from "./route";
+
+// Mock dependencies
+vi.mock("@/lib/auth/server", () => ({
+  getCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/rag/service", () => ({
+  ragService: {
+    listCollections: vi.fn(),
+    deleteFile: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { getCurrentUserId } from "@/lib/auth/server";
+import { ragService } from "@/lib/rag/service";
+import { createClient } from "@/lib/supabase/server";
+
+describe("DELETE /api/documents/[documentId]/file/[fileName]", () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSupabase = {
+      storage: {
+        from: vi.fn(() => ({
+          remove: vi.fn(),
+          list: vi.fn(),
+        })),
+      },
+    };
+
+    vi.mocked(createClient).mockResolvedValue(mockSupabase);
+  });
+
+  it("should return 401 if user is not authenticated", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue(null);
+
+    const request = new Request(
+      "http://localhost/api/documents/doc1/file/test.txt",
+      {
+        method: "DELETE",
+      },
+    );
+
+    const params = Promise.resolve({
+      documentId: "doc1",
+      fileName: "test.txt",
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Authentication required");
+  });
+
+  it("should return 500 if file deletion from storage fails", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+
+    const mockRemove = vi
+      .fn()
+      .mockResolvedValue({ error: { message: "Delete failed" } });
+
+    mockSupabase.storage.from.mockReturnValue({
+      remove: mockRemove,
+      list: vi.fn(),
+    });
+
+    const request = new Request(
+      "http://localhost/api/documents/doc1/file/test.txt",
+      {
+        method: "DELETE",
+      },
+    );
+
+    const params = Promise.resolve({
+      documentId: "doc1",
+      fileName: "test.txt",
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to delete file");
+    expect(mockRemove).toHaveBeenCalledWith(["user1/doc1/test.txt"]);
+  });
+
+  it("should successfully delete file and remove from RAG", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+    vi.mocked(ragService.listCollections).mockResolvedValue([
+      "collection1",
+      "collection2",
+    ]);
+    vi.mocked(ragService.deleteFile).mockResolvedValue();
+
+    const mockRemove = vi.fn().mockResolvedValue({ error: null });
+
+    mockSupabase.storage.from.mockReturnValue({
+      remove: mockRemove,
+    });
+
+    const request = new Request(
+      "http://localhost/api/documents/doc1/file/test.txt",
+      {
+        method: "DELETE",
+      },
+    );
+
+    const params = Promise.resolve({
+      documentId: "doc1",
+      fileName: "test.txt",
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+
+    // Verify file was deleted from storage
+    expect(mockRemove).toHaveBeenCalledWith(["user1/doc1/test.txt"]);
+
+    // Verify RAG deletion was called for all collections
+    expect(ragService.deleteFile).toHaveBeenCalledTimes(2);
+    expect(ragService.deleteFile).toHaveBeenCalledWith(
+      "doc1",
+      "test.txt",
+      "collection1",
+    );
+    expect(ragService.deleteFile).toHaveBeenCalledWith(
+      "doc1",
+      "test.txt",
+      "collection2",
+    );
+  });
+
+  it("should still succeed even if RAG deletion fails", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+    vi.mocked(ragService.listCollections).mockResolvedValue(["collection1"]);
+    vi.mocked(ragService.deleteFile).mockRejectedValue(
+      new Error("RAG deletion failed"),
+    );
+
+    const mockRemove = vi.fn().mockResolvedValue({ error: null });
+
+    mockSupabase.storage.from.mockReturnValue({
+      remove: mockRemove,
+    });
+
+    const request = new Request(
+      "http://localhost/api/documents/doc1/file/test.txt",
+      {
+        method: "DELETE",
+      },
+    );
+
+    const params = Promise.resolve({
+      documentId: "doc1",
+      fileName: "test.txt",
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    // Should still succeed because file is deleted from storage
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+
+  it("should handle files with special characters in name", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+    vi.mocked(ragService.listCollections).mockResolvedValue([]);
+
+    const mockRemove = vi.fn().mockResolvedValue({ error: null });
+
+    mockSupabase.storage.from.mockReturnValue({
+      remove: mockRemove,
+    });
+
+    const fileName = "test file (1).txt";
+    const request = new Request(
+      `http://localhost/api/documents/doc1/file/${encodeURIComponent(fileName)}`,
+      {
+        method: "DELETE",
+      },
+    );
+
+    const params = Promise.resolve({
+      documentId: "doc1",
+      fileName: fileName,
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockRemove).toHaveBeenCalledWith([`user1/doc1/${fileName}`]);
+  });
+});

--- a/src/app/api/documents/[documentId]/file/[fileName]/route.ts
+++ b/src/app/api/documents/[documentId]/file/[fileName]/route.ts
@@ -38,9 +38,17 @@ export async function DELETE(
 
     // Delete from RAG if this is the only file in the document
     try {
-      const { data: remainingFiles } = await supabase.storage
+      const { data: remainingFiles, error: listError } = await supabase.storage
         .from(STORAGE_BUCKET)
         .list(`${userId}/${documentId}`);
+
+      if (listError) {
+        console.error("Failed to check remaining files:", listError);
+        return NextResponse.json(
+          { error: "Failed to verify document state" },
+          { status: 500 },
+        );
+      }
 
       if (!remainingFiles || remainingFiles.length === 0) {
         const collections = await ragService.listCollections();

--- a/src/app/api/documents/[documentId]/file/[fileName]/route.ts
+++ b/src/app/api/documents/[documentId]/file/[fileName]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { getCurrentUserId } from "@/lib/auth/server";
+import { ragService } from "@/lib/rag/service";
+import { createClient } from "@/lib/supabase/server";
+
+const STORAGE_BUCKET = "documents";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ documentId: string; fileName: string }> },
+) {
+  try {
+    const { documentId, fileName } = await params;
+    const userId = await getCurrentUserId();
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const supabase = await createClient();
+    const filePath = `${userId}/${documentId}/${fileName}`;
+
+    // Delete file from Storage
+    const { error: deleteError } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .remove([filePath]);
+
+    if (deleteError) {
+      console.error("Failed to delete file:", deleteError);
+      return NextResponse.json(
+        { error: "Failed to delete file" },
+        { status: 500 },
+      );
+    }
+
+    // Delete from RAG if this is the only file in the document
+    try {
+      const { data: remainingFiles } = await supabase.storage
+        .from(STORAGE_BUCKET)
+        .list(`${userId}/${documentId}`);
+
+      if (!remainingFiles || remainingFiles.length === 0) {
+        const collections = await ragService.listCollections();
+        for (const collectionName of collections) {
+          await ragService.deleteDocument(documentId, collectionName);
+        }
+      }
+    } catch (ragError) {
+      console.error("Failed to delete from RAG:", ragError);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting file:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/documents/[documentId]/route.ts
+++ b/src/app/api/documents/[documentId]/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { getCurrentUserId } from "@/lib/auth/server";
+import { ragService } from "@/lib/rag/service";
+import { createClient } from "@/lib/supabase/server";
+
+const STORAGE_BUCKET = "documents";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ documentId: string }> },
+) {
+  try {
+    const { documentId } = await params;
+    const userId = await getCurrentUserId();
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const supabase = await createClient();
+    const folderPath = `${userId}/${documentId}`;
+
+    // List all files in the document folder
+    const { data: files, error: listError } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .list(folderPath);
+
+    if (listError) {
+      console.error("Failed to list files:", listError);
+      return NextResponse.json(
+        { error: "Failed to delete document" },
+        { status: 500 },
+      );
+    }
+
+    // Delete all files in Storage
+    if (files && files.length > 0) {
+      const filePaths = files.map((file) => `${folderPath}/${file.name}`);
+
+      const { error: deleteError } = await supabase.storage
+        .from(STORAGE_BUCKET)
+        .remove(filePaths);
+
+      if (deleteError) {
+        console.error("Failed to delete files:", deleteError);
+        return NextResponse.json(
+          { error: "Failed to delete document files" },
+          { status: 500 },
+        );
+      }
+    }
+
+    // Delete from RAG (ChromaDB) - try all collections
+    try {
+      const collections = await ragService.listCollections();
+      for (const collectionName of collections) {
+        await ragService.deleteDocument(documentId, collectionName);
+      }
+    } catch (ragError) {
+      console.error("Failed to delete from RAG:", ragError);
+      // Continue even if RAG deletion fails
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting document:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/documents/move/route.test.ts
+++ b/src/app/api/documents/move/route.test.ts
@@ -1,0 +1,316 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+// Mock dependencies
+vi.mock("@/lib/auth/server", () => ({
+  getCurrentUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/rag/service", () => ({
+  ragService: {
+    listCollections: vi.fn(),
+    updateDocumentMetadata: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { getCurrentUserId } from "@/lib/auth/server";
+import { ragService } from "@/lib/rag/service";
+import { createClient } from "@/lib/supabase/server";
+
+describe("POST /api/documents/move", () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSupabase = {
+      storage: {
+        from: vi.fn(() => ({
+          list: vi.fn(),
+          move: vi.fn(),
+        })),
+      },
+    };
+
+    vi.mocked(createClient).mockResolvedValue(mockSupabase);
+  });
+
+  it("should return 401 if user is not authenticated", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue(null);
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Authentication required");
+  });
+
+  it("should return 400 if required fields are missing", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/file.txt",
+        fromDocId: "doc1",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Missing required fields");
+  });
+
+  it("should return 400 if filename cannot be extracted", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Invalid file path");
+  });
+
+  it("should return 403 if source file path does not belong to user", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user2/doc1/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe("Unauthorized: Invalid file path");
+  });
+
+  it("should return 403 if source file path does not match fromDocId", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/wrongDoc/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe("Unauthorized: Invalid file path");
+  });
+
+  it("should return 403 if destination folder does not exist", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+
+    const mockList = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "Not found" },
+    });
+
+    mockSupabase.storage.from.mockReturnValue({
+      list: mockList,
+      move: vi.fn(),
+    });
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe("Unauthorized: Invalid destination folder");
+    expect(mockList).toHaveBeenCalledWith("user1/doc2", { limit: 1 });
+  });
+
+  it("should return 500 if file move fails", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+
+    const mockList = vi.fn().mockResolvedValue({ data: [], error: null });
+    const mockMove = vi
+      .fn()
+      .mockResolvedValue({ error: { message: "Move failed" } });
+
+    mockSupabase.storage.from.mockReturnValue({
+      list: mockList,
+      move: mockMove,
+    });
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to move file");
+  });
+
+  it("should rollback and return 500 if RAG update fails", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+    vi.mocked(ragService.listCollections).mockResolvedValue(["collection1"]);
+    vi.mocked(ragService.updateDocumentMetadata).mockRejectedValue(
+      new Error("RAG update failed"),
+    );
+
+    const mockList = vi.fn().mockResolvedValue({ data: [], error: null });
+    const mockMove = vi.fn().mockResolvedValue({ error: null });
+
+    mockSupabase.storage.from.mockReturnValue({
+      list: mockList,
+      move: mockMove,
+    });
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe("Failed to update search index");
+    // Verify rollback was attempted
+    expect(mockMove).toHaveBeenCalledTimes(2);
+    expect(mockMove).toHaveBeenLastCalledWith(
+      "user1/doc2/file.txt",
+      "user1/doc1/file.txt",
+    );
+  });
+
+  it("should return specific error if rollback also fails", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+    vi.mocked(ragService.listCollections).mockResolvedValue(["collection1"]);
+    vi.mocked(ragService.updateDocumentMetadata).mockRejectedValue(
+      new Error("RAG update failed"),
+    );
+
+    const mockList = vi.fn().mockResolvedValue({ data: [], error: null });
+    const mockMove = vi
+      .fn()
+      .mockResolvedValueOnce({ error: null }) // Initial move succeeds
+      .mockResolvedValueOnce({ error: { message: "Rollback failed" } }); // Rollback fails
+
+    mockSupabase.storage.from.mockReturnValue({
+      list: mockList,
+      move: mockMove,
+    });
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toBe(
+      "Failed to update search index and rollback failed - system in inconsistent state",
+    );
+  });
+
+  it("should successfully move file and update RAG metadata", async () => {
+    vi.mocked(getCurrentUserId).mockResolvedValue("user1");
+    vi.mocked(ragService.listCollections).mockResolvedValue([
+      "collection1",
+      "collection2",
+    ]);
+    vi.mocked(ragService.updateDocumentMetadata).mockResolvedValue();
+
+    const mockList = vi.fn().mockResolvedValue({ data: [], error: null });
+    const mockMove = vi.fn().mockResolvedValue({ error: null });
+
+    mockSupabase.storage.from.mockReturnValue({
+      list: mockList,
+      move: mockMove,
+    });
+
+    const request = new Request("http://localhost/api/documents/move", {
+      method: "POST",
+      body: JSON.stringify({
+        filePath: "user1/doc1/file.txt",
+        fromDocId: "doc1",
+        toDocId: "doc2",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.newPath).toBe("user1/doc2/file.txt");
+
+    // Verify RAG update was called for all collections
+    expect(ragService.updateDocumentMetadata).toHaveBeenCalledTimes(2);
+    expect(ragService.updateDocumentMetadata).toHaveBeenCalledWith(
+      "doc1",
+      "doc2",
+      "file.txt",
+      "collection1",
+    );
+    expect(ragService.updateDocumentMetadata).toHaveBeenCalledWith(
+      "doc1",
+      "doc2",
+      "file.txt",
+      "collection2",
+    );
+  });
+});

--- a/src/app/api/documents/move/route.ts
+++ b/src/app/api/documents/move/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { getCurrentUserId } from "@/lib/auth/server";
+import { ragService } from "@/lib/rag/service";
+import { createClient } from "@/lib/supabase/server";
+
+const STORAGE_BUCKET = "documents";
+
+export async function POST(request: Request) {
+  try {
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const { filePath, fromDocId, toDocId } = await request.json();
+
+    if (!filePath || !fromDocId || !toDocId) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 },
+      );
+    }
+
+    const supabase = await createClient();
+
+    // Extract filename from path
+    const fileName = filePath.split("/").pop();
+    const newPath = `${userId}/${toDocId}/${fileName}`;
+
+    // Move file in Storage
+    const { error: moveError } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .move(filePath, newPath);
+
+    if (moveError) {
+      console.error("Failed to move file:", moveError);
+      return NextResponse.json(
+        { error: "Failed to move file" },
+        { status: 500 },
+      );
+    }
+
+    // Update RAG metadata - search all collections
+    try {
+      const collections = await ragService.listCollections();
+      for (const collectionName of collections) {
+        const collection = await ragService.getCollection(collectionName);
+
+        // Get all chunks with this originalDocId
+        const results = await collection.get({
+          where: { originalDocId: fromDocId },
+        });
+
+        if (results.ids.length > 0) {
+          // Update metadata for all chunks
+          const updatedMetadatas = results.metadatas.map((meta) => ({
+            ...meta,
+            originalDocId: toDocId,
+          }));
+
+          await collection.update({
+            ids: results.ids,
+            metadatas: updatedMetadatas,
+          });
+        }
+      }
+    } catch (ragError) {
+      console.error("Failed to update RAG metadata:", ragError);
+      // Continue even if RAG update fails
+    }
+
+    return NextResponse.json({ success: true, newPath });
+  } catch (error) {
+    console.error("Error moving file:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/documents/move/route.ts
+++ b/src/app/api/documents/move/route.ts
@@ -28,6 +28,19 @@ export async function POST(request: Request) {
 
     // Extract filename from path
     const fileName = filePath.split("/").pop();
+    if (!fileName) {
+      return NextResponse.json({ error: "Invalid file path" }, { status: 400 });
+    }
+
+    // Validate that filePath belongs to current user and fromDocId
+    const expectedPrefix = `${userId}/${fromDocId}/`;
+    if (!filePath.startsWith(expectedPrefix)) {
+      return NextResponse.json(
+        { error: "Unauthorized: Invalid file path" },
+        { status: 403 },
+      );
+    }
+
     const newPath = `${userId}/${toDocId}/${fileName}`;
 
     // Move file in Storage
@@ -50,6 +63,7 @@ export async function POST(request: Request) {
         await ragService.updateDocumentMetadata(
           fromDocId,
           toDocId,
+          fileName,
           collectionName,
         );
       }

--- a/src/app/api/documents/move/route.ts
+++ b/src/app/api/documents/move/route.ts
@@ -69,7 +69,12 @@ export async function POST(request: Request) {
       }
     } catch (ragError) {
       console.error("Failed to update RAG metadata:", ragError);
-      // Continue even if RAG update fails
+      // Rollback: move file back to original location
+      await supabase.storage.from(STORAGE_BUCKET).move(newPath, filePath);
+      return NextResponse.json(
+        { error: "Failed to update search index" },
+        { status: 500 },
+      );
     }
 
     return NextResponse.json({ success: true, newPath });

--- a/src/app/api/documents/move/route.ts
+++ b/src/app/api/documents/move/route.ts
@@ -47,25 +47,11 @@ export async function POST(request: Request) {
     try {
       const collections = await ragService.listCollections();
       for (const collectionName of collections) {
-        const collection = await ragService.getCollection(collectionName);
-
-        // Get all chunks with this originalDocId
-        const results = await collection.get({
-          where: { originalDocId: fromDocId },
-        });
-
-        if (results.ids.length > 0) {
-          // Update metadata for all chunks
-          const updatedMetadatas = results.metadatas.map((meta) => ({
-            ...meta,
-            originalDocId: toDocId,
-          }));
-
-          await collection.update({
-            ids: results.ids,
-            metadatas: updatedMetadatas,
-          });
-        }
+        await ragService.updateDocumentMetadata(
+          fromDocId,
+          toDocId,
+          collectionName,
+        );
       }
     } catch (ragError) {
       console.error("Failed to update RAG metadata:", ragError);

--- a/src/app/api/documents/move/route.ts
+++ b/src/app/api/documents/move/route.ts
@@ -42,11 +42,14 @@ export async function POST(request: Request) {
     }
 
     // Validate destination folder belongs to current user
+    // Note: Supabase returns an empty array for non-existent paths, not null
     const { data: destCheck, error: destCheckError } = await supabase.storage
       .from(STORAGE_BUCKET)
       .list(`${userId}/${toDocId}`, { limit: 1 });
 
-    if (destCheckError || !destCheck) {
+    // Reject if there's an error, destCheck is null, or the folder doesn't exist (empty array)
+    // An existing folder will have at least one entry (files or .emptyFolderPlaceholder)
+    if (destCheckError || !destCheck || destCheck.length === 0) {
       return NextResponse.json(
         { error: "Unauthorized: Invalid destination folder" },
         { status: 403 },

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { getCurrentUserId } from "@/lib/auth/server";
+import { createClient } from "@/lib/supabase/server";
+
+const STORAGE_BUCKET = "documents";
+
+export async function GET() {
+  try {
+    const userId = await getCurrentUserId();
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    const supabase = await createClient();
+
+    // List all document folders (first level: documentId folders)
+    const { data: folders, error: foldersError } = await supabase.storage
+      .from(STORAGE_BUCKET)
+      .list(userId, {
+        limit: 1000,
+        sortBy: { column: "created_at", order: "desc" },
+      });
+
+    if (foldersError) {
+      console.error("Failed to list folders:", foldersError);
+      return NextResponse.json(
+        { error: "Failed to retrieve documents" },
+        { status: 500 },
+      );
+    }
+
+    console.log("User ID:", userId);
+    console.log("Folders found:", folders?.length || 0);
+
+    // Process all folders in parallel
+    const folderPromises = (folders || [])
+      .filter((folder) => folder.id === null) // Only process folders
+      .map(async (folder) => {
+        const { data: files, error: filesError } = await supabase.storage
+          .from(STORAGE_BUCKET)
+          .list(`${userId}/${folder.name}`, {
+            limit: 100,
+            sortBy: { column: "created_at", order: "desc" },
+          });
+
+        if (filesError) {
+          console.error(`Failed to list files in ${folder.name}:`, filesError);
+          return [];
+        }
+
+        // Process all files in this folder in parallel
+        const filePromises = (files || [])
+          .filter((file) => file.id !== null) // Only process files
+          .map(async (file) => {
+            const filePath = `${userId}/${folder.name}/${file.name}`;
+
+            const { data: urlData } = await supabase.storage
+              .from(STORAGE_BUCKET)
+              .createSignedUrl(filePath, 3600);
+
+            return {
+              documentId: folder.name,
+              fileName: file.name,
+              filePath,
+              size: file.metadata?.size || 0,
+              createdAt: file.created_at || new Date().toISOString(),
+              downloadUrl: urlData?.signedUrl || null,
+            };
+          });
+
+        return Promise.all(filePromises);
+      });
+
+    const documentsNested = await Promise.all(folderPromises);
+    const documents = documentsNested.flat();
+
+    return NextResponse.json({ documents });
+  } catch (error) {
+    console.error("Error listing documents:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -32,9 +32,6 @@ export async function GET() {
       );
     }
 
-    console.log("User ID:", userId);
-    console.log("Folders found:", folders?.length || 0);
-
     // Process all folders in parallel
     const folderPromises = (folders || [])
       .filter((folder) => folder.id === null) // Only process folders

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -122,10 +122,10 @@ export default function AIElementsChatShowcase() {
   const [model, setModel] = useState<string>("openai/gpt-5-nano");
   const [searchProviders, setSearchProviders] = useState<string[]>([]);
   const [ragEnabled, setRagEnabled] = useState<boolean>(false);
-  const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
+  const [_uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const [uploading, setUploading] = useState(false);
-  const [uploadStatus, setUploadStatus] = useState<string>("");
+  const [_uploading, setUploading] = useState(false);
+  const [_uploadStatus, setUploadStatus] = useState<string>("");
 
   // Get current model's provider and name for display
   const currentModel = providers
@@ -143,7 +143,7 @@ export default function AIElementsChatShowcase() {
   } = useChat();
 
   // Handle file upload to vector database
-  const handleUploadToVectorDB = async () => {
+  const _handleUploadToVectorDB = async () => {
     if (selectedFiles.length === 0) return;
 
     setUploading(true);
@@ -263,7 +263,12 @@ export default function AIElementsChatShowcase() {
         <div className="max-w-4xl mx-auto">
           {/* Header */}
           <div className="mb-8">
-            <h1 className="text-3xl font-bold mb-2">AI Elements Chat</h1>
+            <div className="flex items-center justify-between mb-2">
+              <h1 className="text-3xl font-bold">AI Elements Chat</h1>
+              <Button asChild variant="outline">
+                <a href="/documents">Manage Documents</a>
+              </Button>
+            </div>
             <p className="text-muted-foreground">
               Enhanced chat interface with file attachments, model selection,
               and web search

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -142,48 +142,6 @@ export default function AIElementsChatShowcase() {
     regenerate: originalRegenerate,
   } = useChat();
 
-  // Handle file upload to vector database
-  const _handleUploadToVectorDB = async () => {
-    if (selectedFiles.length === 0) return;
-
-    setUploading(true);
-    setUploadStatus("Uploading files...");
-
-    try {
-      const formData = new FormData();
-      selectedFiles.forEach((file) => {
-        formData.append("files", file);
-      });
-
-      const response = await fetch("/api/rag/ingest", {
-        method: "POST",
-        body: formData,
-      });
-
-      if (!response.ok) {
-        throw new Error("Upload failed");
-      }
-
-      const result = await response.json();
-      setUploadStatus(
-        `✅ Success! Indexed ${result.totalChunks} chunks from ${selectedFiles.length} file(s)`,
-      );
-      setSelectedFiles([]);
-
-      // Close dialog after 2 seconds
-      setTimeout(() => {
-        setUploadDialogOpen(false);
-        setUploadStatus("");
-      }, 2000);
-    } catch (error) {
-      setUploadStatus(
-        `❌ Upload failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
-    } finally {
-      setUploading(false);
-    }
-  };
-
   // Custom regenerate function that includes our body parameters
   const regenerate = () => {
     originalRegenerate({

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -122,10 +122,7 @@ export default function AIElementsChatShowcase() {
   const [model, setModel] = useState<string>("openai/gpt-5-nano");
   const [searchProviders, setSearchProviders] = useState<string[]>([]);
   const [ragEnabled, setRagEnabled] = useState<boolean>(false);
-  const [_uploadDialogOpen, setUploadDialogOpen] = useState(false);
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
-  const [_uploading, setUploading] = useState(false);
-  const [_uploadStatus, setUploadStatus] = useState<string>("");
+  const [uploading, setUploading] = useState(false);
 
   // Get current model's provider and name for display
   const currentModel = providers

--- a/src/app/documents/components/draggable-file.tsx
+++ b/src/app/documents/components/draggable-file.tsx
@@ -1,0 +1,111 @@
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  DownloadIcon,
+  FileTextIcon,
+  Loader2Icon,
+  MoreHorizontalIcon,
+  TrashIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface DraggableFileProps {
+  file: {
+    filePath: string;
+    fileName: string;
+    size: number;
+    createdAt: string;
+    downloadUrl: string | null;
+  };
+  documentId: string;
+  movingFile: string | null;
+  formatFileSize: (bytes: number) => string;
+  formatDate: (date: string) => string;
+  onDeleteFile: (filePath: string, documentId: string) => void;
+}
+
+export function DraggableFile({
+  file,
+  documentId,
+  movingFile,
+  formatFileSize,
+  formatDate,
+  onDeleteFile,
+}: DraggableFileProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: file.filePath,
+    });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="grid grid-cols-[1fr_auto_auto_auto] gap-4 px-4 py-2 border-b last:border-b-0 hover:bg-accent/50 items-center"
+    >
+      <div
+        {...listeners}
+        {...attributes}
+        className="flex items-center gap-2 min-w-0 pl-6 cursor-move"
+      >
+        <FileTextIcon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+        <span className="truncate text-sm">{file.fileName}</span>
+      </div>
+      <div className="text-sm text-muted-foreground whitespace-nowrap">
+        {formatFileSize(file.size)}
+      </div>
+      <div className="text-sm text-muted-foreground whitespace-nowrap">
+        {formatDate(file.createdAt)}
+      </div>
+      <div className="flex items-center gap-1">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={movingFile === file.filePath}
+            >
+              {movingFile === file.filePath ? (
+                <Loader2Icon className="h-4 w-4 animate-spin" />
+              ) : (
+                <MoreHorizontalIcon className="h-4 w-4" />
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {file.downloadUrl && (
+              <DropdownMenuItem asChild>
+                <a
+                  href={file.downloadUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <DownloadIcon className="h-4 w-4 mr-2" />
+                  Download
+                </a>
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              onClick={() => onDeleteFile(file.filePath, documentId)}
+              className="text-destructive"
+            >
+              <TrashIcon className="h-4 w-4 mr-2" />
+              Delete File
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/src/app/documents/components/droppable-folder.tsx
+++ b/src/app/documents/components/droppable-folder.tsx
@@ -1,0 +1,67 @@
+import { useDroppable } from "@dnd-kit/core";
+import {
+  FolderIcon,
+  Loader2Icon,
+  MoreHorizontalIcon,
+  TrashIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface DroppableFolderProps {
+  documentId: string;
+  fileCount: number;
+  deletingId: string | null;
+  onDeleteFolder: (documentId: string) => void;
+}
+
+export function DroppableFolder({
+  documentId,
+  fileCount,
+  deletingId,
+  onDeleteFolder,
+}: DroppableFolderProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: documentId,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex items-center justify-between px-4 py-2 bg-muted/30 border-b transition-colors ${
+        isOver ? "bg-primary/20" : ""
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <FolderIcon className="h-4 w-4 text-muted-foreground" />
+        <span className="font-mono text-sm">{documentId}</span>
+        <span className="text-xs text-muted-foreground">({fileCount})</span>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="sm">
+            {deletingId === documentId ? (
+              <Loader2Icon className="h-4 w-4 animate-spin" />
+            ) : (
+              <MoreHorizontalIcon className="h-4 w-4" />
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => onDeleteFolder(documentId)}
+            className="text-destructive"
+          >
+            <TrashIcon className="h-4 w-4 mr-2" />
+            Delete Folder
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/src/app/documents/page.tsx
+++ b/src/app/documents/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import {
+  DownloadIcon,
+  FileTextIcon,
+  FolderIcon,
+  Loader2Icon,
+  MoreHorizontalIcon,
+  TrashIcon,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useAuth } from "@/lib/auth/auth-context";
+
+interface DocumentFile {
+  documentId: string;
+  fileName: string;
+  filePath: string;
+  size: number;
+  createdAt: string;
+  downloadUrl: string | null;
+}
+
+export default function DocumentsPage() {
+  const { userId, isLoading: authLoading } = useAuth();
+  const [documents, setDocuments] = useState<DocumentFile[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [movingFile, setMovingFile] = useState<string | null>(null);
+  const [dragOverFolder, setDragOverFolder] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (authLoading || !userId) return;
+
+    async function fetchDocuments() {
+      try {
+        const response = await fetch("/api/documents");
+        if (!response.ok) throw new Error("Failed to fetch documents");
+
+        const data = await response.json();
+        setDocuments(data.documents || []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchDocuments();
+  }, [userId, authLoading]);
+
+  async function handleDeleteFolder(documentId: string) {
+    if (!confirm("Are you sure you want to delete this folder?")) return;
+
+    setDeletingId(documentId);
+    try {
+      const response = await fetch(`/api/documents/${documentId}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) throw new Error("Failed to delete document");
+
+      setDocuments((prev) =>
+        prev.filter((doc) => doc.documentId !== documentId),
+      );
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to delete document");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  async function handleDeleteFile(filePath: string, documentId: string) {
+    if (!confirm("Are you sure you want to delete this file?")) return;
+
+    setMovingFile(filePath);
+    try {
+      // Extract just the filename from the path
+      const fileName = filePath.split("/").pop();
+
+      const response = await fetch(
+        `/api/documents/${documentId}/file/${fileName}`,
+        { method: "DELETE" },
+      );
+
+      if (!response.ok) throw new Error("Failed to delete file");
+
+      setDocuments((prev) => prev.filter((doc) => doc.filePath !== filePath));
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to delete file");
+    } finally {
+      setMovingFile(null);
+    }
+  }
+
+  async function handleMove(
+    filePath: string,
+    fromDocId: string,
+    toDocId: string,
+  ) {
+    setMovingFile(filePath);
+    try {
+      const response = await fetch("/api/documents/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filePath, fromDocId, toDocId }),
+      });
+
+      if (!response.ok) throw new Error("Failed to move file");
+
+      const data = await response.json();
+
+      setDocuments((prev) =>
+        prev.map((doc) =>
+          doc.filePath === filePath
+            ? { ...doc, documentId: toDocId, filePath: data.newPath }
+            : doc,
+        ),
+      );
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to move file");
+    } finally {
+      setMovingFile(null);
+    }
+  }
+
+  function formatFileSize(bytes: number): string {
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${Math.round((bytes / k ** i) * 100) / 100} ${sizes[i]}`;
+  }
+
+  function formatDate(dateString: string): string {
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  }
+
+  if (authLoading || isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="flex items-center gap-2">
+          <Loader2Icon className="h-5 w-5 animate-spin" />
+          <span className="text-muted-foreground">Loading documents...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-destructive">Error: {error}</div>
+      </div>
+    );
+  }
+
+  // Group documents by documentId
+  const groupedDocs = documents.reduce(
+    (acc, doc) => {
+      if (!acc[doc.documentId]) {
+        acc[doc.documentId] = [];
+      }
+      acc[doc.documentId].push(doc);
+      return acc;
+    },
+    {} as Record<string, DocumentFile[]>,
+  );
+
+  const _allFolders = Object.keys(groupedDocs);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto py-8 px-4 max-w-6xl">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl font-semibold">Documents</h1>
+          <Button asChild variant="outline" size="sm">
+            <a href="/chat">Back to Chat</a>
+          </Button>
+        </div>
+
+        {documents.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            <p>No documents uploaded yet</p>
+          </div>
+        ) : (
+          <div className="border rounded-lg overflow-hidden">
+            {Object.entries(groupedDocs).map(([documentId, files]) => (
+              <div key={documentId}>
+                {/* Folder Header */}
+                <div
+                  className={`flex items-center justify-between px-4 py-2 bg-muted/30 border-b transition-colors ${
+                    dragOverFolder === documentId ? "bg-primary/20" : ""
+                  }`}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragOverFolder(documentId);
+                  }}
+                  onDragLeave={() => {
+                    setDragOverFolder(null);
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const data = e.dataTransfer.getData("application/json");
+                    if (data) {
+                      const { filePath, fromDocId } = JSON.parse(data);
+                      if (fromDocId !== documentId) {
+                        handleMove(filePath, fromDocId, documentId);
+                      }
+                    }
+                    setDragOverFolder(null);
+                  }}
+                >
+                  <div className="flex items-center gap-2">
+                    <FolderIcon className="h-4 w-4 text-muted-foreground" />
+                    <span className="font-mono text-sm">{documentId}</span>
+                    <span className="text-xs text-muted-foreground">
+                      ({files.length})
+                    </span>
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="sm">
+                        {deletingId === documentId ? (
+                          <Loader2Icon className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <MoreHorizontalIcon className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => handleDeleteFolder(documentId)}
+                        className="text-destructive"
+                      >
+                        <TrashIcon className="h-4 w-4 mr-2" />
+                        Delete Folder
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                {/* File List */}
+                {files.map((file) => (
+                  <div
+                    key={file.filePath}
+                    draggable
+                    onDragStart={(e) => {
+                      e.dataTransfer.setData(
+                        "application/json",
+                        JSON.stringify({
+                          filePath: file.filePath,
+                          fromDocId: documentId,
+                        }),
+                      );
+                    }}
+                    className="grid grid-cols-[1fr_auto_auto_auto] gap-4 px-4 py-2 border-b last:border-b-0 hover:bg-accent/50 items-center cursor-move"
+                  >
+                    <div className="flex items-center gap-2 min-w-0 pl-6">
+                      <FileTextIcon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                      <span className="truncate text-sm">{file.fileName}</span>
+                    </div>
+                    <div className="text-sm text-muted-foreground whitespace-nowrap">
+                      {formatFileSize(file.size)}
+                    </div>
+                    <div className="text-sm text-muted-foreground whitespace-nowrap">
+                      {formatDate(file.createdAt)}
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            disabled={movingFile === file.filePath}
+                          >
+                            {movingFile === file.filePath ? (
+                              <Loader2Icon className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <MoreHorizontalIcon className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          {file.downloadUrl && (
+                            <DropdownMenuItem asChild>
+                              <a
+                                href={file.downloadUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                <DownloadIcon className="h-4 w-4 mr-2" />
+                                Download
+                              </a>
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuItem
+                            onClick={() =>
+                              handleDeleteFile(file.filePath, documentId)
+                            }
+                            className="text-destructive"
+                          >
+                            <TrashIcon className="h-4 w-4 mr-2" />
+                            Delete File
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/rag/service.test.ts
+++ b/src/lib/rag/service.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RAGService } from "./service";
+
+// Mock chromadb
+vi.mock("chromadb", () => {
+  const MockCollection = vi.fn();
+  const MockChromaClient = vi.fn();
+  return {
+    ChromaClient: MockChromaClient,
+  };
+});
+
+// Mock ai embeddings
+vi.mock("ai", () => ({
+  embed: vi.fn(),
+  embedMany: vi.fn(),
+}));
+
+import { embed, embedMany } from "ai";
+import { ChromaClient } from "chromadb";
+
+describe("RAGService", () => {
+  let ragService: RAGService;
+  let mockCollection: any;
+  let mockChromaClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCollection = {
+      get: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+      add: vi.fn(),
+      query: vi.fn(),
+    };
+
+    mockChromaClient = {
+      getOrCreateCollection: vi.fn().mockResolvedValue(mockCollection),
+      listCollections: vi.fn(),
+      deleteCollection: vi.fn(),
+    };
+
+    vi.mocked(ChromaClient).mockImplementation(() => mockChromaClient);
+
+    ragService = new RAGService();
+  });
+
+  describe("deleteDocument", () => {
+    it("should delete all chunks for a document", async () => {
+      const documentId = "doc123";
+      const mockChunkIds = [
+        "doc123_chunk_0",
+        "doc123_chunk_1",
+        "doc123_chunk_2",
+      ];
+
+      mockCollection.get.mockResolvedValue({
+        ids: mockChunkIds,
+      });
+
+      await ragService.deleteDocument(documentId);
+
+      expect(mockCollection.get).toHaveBeenCalledWith({
+        where: { originalDocId: documentId },
+      });
+
+      expect(mockCollection.delete).toHaveBeenCalledWith({
+        ids: mockChunkIds,
+      });
+    });
+
+    it("should not call delete if no chunks found", async () => {
+      mockCollection.get.mockResolvedValue({
+        ids: [],
+      });
+
+      await ragService.deleteDocument("doc123");
+
+      expect(mockCollection.get).toHaveBeenCalled();
+      expect(mockCollection.delete).not.toHaveBeenCalled();
+    });
+
+    it("should handle collection name parameter", async () => {
+      const customCollection = { ...mockCollection };
+      mockChromaClient.getOrCreateCollection.mockResolvedValue(
+        customCollection,
+      );
+
+      customCollection.get.mockResolvedValue({ ids: ["id1"] });
+
+      await ragService.deleteDocument("doc123", "custom_collection");
+
+      expect(mockChromaClient.getOrCreateCollection).toHaveBeenCalledWith({
+        name: "custom_collection",
+        metadata: {
+          description: "RAG document collection with external embeddings",
+          "hnsw:space": "cosine",
+        },
+      });
+    });
+  });
+
+  describe("deleteFile", () => {
+    it("should delete chunks for a specific file", async () => {
+      const documentId = "doc123";
+      const fileName = "test.txt";
+      const mockChunkIds = ["doc123_chunk_0", "doc123_chunk_1"];
+
+      mockCollection.get.mockResolvedValue({
+        ids: mockChunkIds,
+      });
+
+      await ragService.deleteFile(documentId, fileName);
+
+      expect(mockCollection.get).toHaveBeenCalledWith({
+        where: {
+          $and: [{ originalDocId: documentId }, { filename: fileName }],
+        },
+      });
+
+      expect(mockCollection.delete).toHaveBeenCalledWith({
+        ids: mockChunkIds,
+      });
+    });
+
+    it("should not delete chunks from other files in same document", async () => {
+      const documentId = "doc123";
+      const fileName = "file1.txt";
+
+      mockCollection.get.mockResolvedValue({
+        ids: ["doc123_chunk_0"], // Only chunks for file1.txt
+      });
+
+      await ragService.deleteFile(documentId, fileName);
+
+      // Verify query is specific to both documentId AND fileName
+      expect(mockCollection.get).toHaveBeenCalledWith({
+        where: {
+          $and: [{ originalDocId: documentId }, { filename: fileName }],
+        },
+      });
+    });
+
+    it("should not call delete if no chunks found for file", async () => {
+      mockCollection.get.mockResolvedValue({
+        ids: [],
+      });
+
+      await ragService.deleteFile("doc123", "nonexistent.txt");
+
+      expect(mockCollection.get).toHaveBeenCalled();
+      expect(mockCollection.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateDocumentMetadata", () => {
+    it("should update metadata for specific file chunks", async () => {
+      const oldDocId = "doc1";
+      const newDocId = "doc2";
+      const fileName = "test.txt";
+
+      const mockChunkIds = ["doc1_chunk_0", "doc1_chunk_1"];
+      const mockMetadatas = [
+        {
+          filename: fileName,
+          fileType: "text/plain",
+          originalDocId: oldDocId,
+          chunkIndex: 0,
+        },
+        {
+          filename: fileName,
+          fileType: "text/plain",
+          originalDocId: oldDocId,
+          chunkIndex: 1,
+        },
+      ];
+
+      mockCollection.get.mockResolvedValue({
+        ids: mockChunkIds,
+        metadatas: mockMetadatas,
+      });
+
+      await ragService.updateDocumentMetadata(oldDocId, newDocId, fileName);
+
+      expect(mockCollection.get).toHaveBeenCalledWith({
+        where: {
+          $and: [{ originalDocId: oldDocId }, { filename: fileName }],
+        },
+      });
+
+      expect(mockCollection.update).toHaveBeenCalledWith({
+        ids: mockChunkIds,
+        metadatas: [
+          {
+            filename: fileName,
+            fileType: "text/plain",
+            originalDocId: newDocId,
+            chunkIndex: 0,
+          },
+          {
+            filename: fileName,
+            fileType: "text/plain",
+            originalDocId: newDocId,
+            chunkIndex: 1,
+          },
+        ],
+      });
+    });
+
+    it("should not update chunks from other files", async () => {
+      const oldDocId = "doc1";
+      const newDocId = "doc2";
+      const fileName = "file1.txt";
+
+      mockCollection.get.mockResolvedValue({
+        ids: ["doc1_chunk_0"],
+        metadatas: [
+          {
+            filename: fileName,
+            originalDocId: oldDocId,
+          },
+        ],
+      });
+
+      await ragService.updateDocumentMetadata(oldDocId, newDocId, fileName);
+
+      // Verify query filters by both documentId AND fileName
+      expect(mockCollection.get).toHaveBeenCalledWith({
+        where: {
+          $and: [{ originalDocId: oldDocId }, { filename: fileName }],
+        },
+      });
+    });
+
+    it("should not call update if no chunks found", async () => {
+      mockCollection.get.mockResolvedValue({
+        ids: [],
+        metadatas: [],
+      });
+
+      await ragService.updateDocumentMetadata("doc1", "doc2", "test.txt");
+
+      expect(mockCollection.get).toHaveBeenCalled();
+      expect(mockCollection.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listCollections", () => {
+    it("should return list of collection names", async () => {
+      const mockCollections = [
+        { name: "collection1" },
+        { name: "collection2" },
+        { name: "collection3" },
+      ];
+
+      mockChromaClient.listCollections.mockResolvedValue(mockCollections);
+
+      const result = await ragService.listCollections();
+
+      expect(result).toEqual(["collection1", "collection2", "collection3"]);
+      expect(mockChromaClient.listCollections).toHaveBeenCalled();
+    });
+
+    it("should return empty array if no collections", async () => {
+      mockChromaClient.listCollections.mockResolvedValue([]);
+
+      const result = await ragService.listCollections();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("clearCollection", () => {
+    it("should delete collection by name", async () => {
+      const collectionName = "test_collection";
+
+      await ragService.clearCollection(collectionName);
+
+      expect(mockChromaClient.deleteCollection).toHaveBeenCalledWith({
+        name: collectionName,
+      });
+    });
+
+    it("should handle errors gracefully", async () => {
+      const collectionName = "test_collection";
+      mockChromaClient.deleteCollection.mockRejectedValue(
+        new Error("Collection not found"),
+      );
+
+      // Should not throw
+      await expect(
+        ragService.clearCollection(collectionName),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/lib/rag/service.ts
+++ b/src/lib/rag/service.ts
@@ -311,10 +311,16 @@ export class RAGService {
     });
 
     if (results.ids.length > 0) {
-      const updatedMetadatas = results.metadatas?.map((meta) => ({
-        ...meta,
-        originalDocId: newDocumentId,
-      }));
+      // Handle potentially undefined metadatas array and null individual metadata objects
+      const updatedMetadatas =
+        results.metadatas?.map((meta) =>
+          meta
+            ? {
+                ...meta,
+                originalDocId: newDocumentId,
+              }
+            : { originalDocId: newDocumentId },
+        ) || results.ids.map(() => ({ originalDocId: newDocumentId }));
 
       await collection.update({
         ids: results.ids,

--- a/src/lib/rag/service.ts
+++ b/src/lib/rag/service.ts
@@ -276,12 +276,15 @@ export class RAGService {
   async updateDocumentMetadata(
     oldDocumentId: string,
     newDocumentId: string,
+    fileName: string,
     collectionName: string = DEFAULT_COLLECTION,
   ): Promise<void> {
     const collection = await this.getCollection(collectionName);
 
     const results = await collection.get({
-      where: { originalDocId: oldDocumentId },
+      where: {
+        $and: [{ originalDocId: oldDocumentId }, { filename: fileName }],
+      },
     });
 
     if (results.ids.length > 0) {
@@ -296,7 +299,7 @@ export class RAGService {
       });
 
       console.log(
-        `✅ Updated ${results.ids.length} chunks: ${oldDocumentId} → ${newDocumentId}`,
+        `✅ Updated ${results.ids.length} chunks for ${fileName}: ${oldDocumentId} → ${newDocumentId}`,
       );
     }
   }

--- a/src/lib/rag/service.ts
+++ b/src/lib/rag/service.ts
@@ -256,6 +256,29 @@ export class RAGService {
     }
   }
 
+  async deleteFile(
+    documentId: string,
+    fileName: string,
+    collectionName: string = DEFAULT_COLLECTION,
+  ): Promise<void> {
+    const collection = await this.getCollection(collectionName);
+
+    const results = await collection.get({
+      where: {
+        $and: [{ originalDocId: documentId }, { filename: fileName }],
+      },
+    });
+
+    if (results.ids.length > 0) {
+      await collection.delete({
+        ids: results.ids,
+      });
+      console.log(
+        `✅ Deleted ${results.ids.length} chunks for file ${fileName} in doc ${documentId}`,
+      );
+    }
+  }
+
   async clearCollection(
     collectionName: string = DEFAULT_COLLECTION,
   ): Promise<void> {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom";
 // Skip environment validation in tests
 process.env.SKIP_ENV_VALIDATION = "1";
 
-// Set minimal test environment variables
-process.env.NODE_ENV = "test";
-process.env.CHROMA_URL = "http://localhost:8000";
+// Set minimal test environment variables (using type assertion for readonly properties)
+if (!process.env.CHROMA_URL) {
+  (process.env as any).CHROMA_URL = "http://localhost:8000";
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,8 @@
 import "@testing-library/jest-dom";
+
+// Skip environment validation in tests
+process.env.SKIP_ENV_VALIDATION = "1";
+
+// Set minimal test environment variables
+process.env.NODE_ENV = "test";
+process.env.CHROMA_URL = "http://localhost:8000";


### PR DESCRIPTION
## Principles Reminder

- **KISS (Keep It Simple Stupid)**: Avoid unnecessary complexity
- No meaningless comments or descriptions
- No unnecessary abstractions
- Keep code direct and clear
- **LLM Tool Resilience**: Tools designed for LLM use should return error messages rather than fail completely, allowing the LLM to handle and recover from errors gracefully

## Summary

Brief description of what this PR does.

## Changes

- [ ] List your changes here
- [ ] No debug print statements left in code (console.log, print, etc.)

## Testing

How to verify the changes work correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a documents management UI with drag-and-drop and server APIs to list/move/delete files and folders, updating the RAG index accordingly, plus comprehensive tests.
> 
> - **Frontend**
>   - **Documents UI**: New page `src/app/documents/page.tsx` with drag-and-drop (via `@dnd-kit`) to move files across folders; per-file actions (download/delete) using `DraggableFile` and droppable folders via `DroppableFolder`.
>   - **Chat Header**: Adds "Manage Documents" button linking to `/documents`; removes unused upload dialog state.
> - **Backend APIs**
>   - **List Documents**: `GET /api/documents` lists user folders/files from Supabase and returns signed download URLs.
>   - **Move File**: `POST /api/documents/move` moves a file between document folders with validation, rollback on RAG failure, and returns new `filePath`.
>   - **Delete File**: `DELETE /api/documents/[documentId]/file/[fileName]` removes from storage and attempts RAG cleanup.
>   - **Delete Document**: `DELETE /api/documents/[documentId]` bulk-deletes folder files and cleans RAG collections.
> - **RAG Service** (`src/lib/rag/service.ts`)
>   - Adds `deleteFile`, `updateDocumentMetadata`, `listCollections`; updates collection metadata and distance space; improves metadata handling.
> - **Tests**
>   - Adds unit tests for document APIs and RAG service behaviors (list/move/delete, metadata updates, rollback) and test setup env config.
> - **Dependencies**
>   - Adds `@dnd-kit/core` and `@dnd-kit/utilities`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 323b6315c1250b26c6215ebe1c09ad0df937b699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Documents page with grouped folders, file list (size, date, download), drag-and-drop moves with overlay and progress.
  - Server endpoints for listing documents, moving files, deleting individual files and folders; background index/metadata cleanup runs (non-blocking).

- **Refactor**
  - Chat header layout adjusted; file upload UI/state removed from chat.

- **Tests**
  - Comprehensive tests for document APIs and indexing/metadata behaviors; test setup improved for local runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->