### PR TITLE
Add dynamic search provider options with configurable rendering

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -118,6 +118,13 @@ type RAGQueryToolPart = {
 // Dynamically load all available providers
 const providers = loadAllProviders();
 
+const searchProviderOptions = [
+  { id: "tavily" as const, label: "Tavily Search" },
+  { id: "exa" as const, label: "Exa Search" },
+  { id: "perplexity" as const, label: "Perplexity Search" },
+  { id: "bing" as const, label: "Bing Search (Coming Soon)", disabled: true },
+];
+
 export default function AIElementsChatShowcase() {
   const [model, setModel] = useState<string>("openai/gpt-5-nano");
   const [searchProviders, setSearchProviders] = useState<string[]>([]);
@@ -674,66 +681,27 @@ export default function AIElementsChatShowcase() {
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-56">
-                      <DropdownMenuCheckboxItem
-                        checked={searchProviders.includes("tavily")}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            setSearchProviders([...searchProviders, "tavily"]);
-                          } else {
-                            setSearchProviders(
-                              searchProviders.filter((p) => p !== "tavily"),
-                            );
-                          }
-                        }}
-                      >
-                        Tavily Search
-                      </DropdownMenuCheckboxItem>
-                      <DropdownMenuCheckboxItem
-                        checked={searchProviders.includes("exa")}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            setSearchProviders([...searchProviders, "exa"]);
-                          } else {
-                            setSearchProviders(
-                              searchProviders.filter((p) => p !== "exa"),
-                            );
-                          }
-                        }}
-                      >
-                        Exa Search
-                      </DropdownMenuCheckboxItem>
-                      <DropdownMenuCheckboxItem
-                        checked={searchProviders.includes("bing")}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            setSearchProviders([...searchProviders, "bing"]);
-                          } else {
-                            setSearchProviders(
-                              searchProviders.filter((p) => p !== "bing"),
-                            );
-                          }
-                        }}
-                        disabled
-                      >
-                        Bing Search (Coming Soon)
-                      </DropdownMenuCheckboxItem>
-                      <DropdownMenuCheckboxItem
-                        checked={searchProviders.includes("perplexity")}
-                        onCheckedChange={(checked) => {
-                          if (checked) {
-                            setSearchProviders([
-                              ...searchProviders,
-                              "perplexity",
-                            ]);
-                          } else {
-                            setSearchProviders(
-                              searchProviders.filter((p) => p !== "perplexity"),
-                            );
-                          }
-                        }}
-                      >
-                        Perplexity Search
-                      </DropdownMenuCheckboxItem>
+                      {searchProviderOptions.map((option) => (
+                        <DropdownMenuCheckboxItem
+                          key={option.id}
+                          checked={searchProviders.includes(option.id)}
+                          onCheckedChange={(checked) => {
+                            if (checked) {
+                              setSearchProviders([
+                                ...searchProviders,
+                                option.id,
+                              ]);
+                            } else {
+                              setSearchProviders(
+                                searchProviders.filter((p) => p !== option.id),
+                              );
+                            }
+                          }}
+                          disabled={option.disabled}
+                        >
+                          {option.label}
+                        </DropdownMenuCheckboxItem>
+                      ))}
                     </DropdownMenuContent>
                   </DropdownMenu>
                   {/* Nested Model Selection with Provider Hover Submenus */}


### PR DESCRIPTION
## Principles Reminder

- **KISS (Keep It Simple Stupid)**: Avoid unnecessary complexity
- No meaningless comments or descriptions
- No unnecessary abstractions
- Keep code direct and clear
- **LLM Tool Resilience**: Tools designed for LLM use should return error messages rather than fail completely, allowing the LLM to handle and recover from errors gracefully

## Summary

Brief description of what this PR does.

## Changes

- [ ] List your changes here
- [ ] No debug print statements left in code (console.log, print, etc.)

## Testing

How to verify the changes work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the search provider selection UI by consolidating provider options into a unified list, improving consistency and scalability.
  * Ensured each provider displays a single, clear checkbox with accurate checked/disabled states.
  * Centralized labels for providers for more consistent naming across the UI.
  * Bing remains visible but disabled, matching previous behavior.
  * No functional changes to how provider selections are saved or applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->