### PR TITLE
Zxzinn/spa 54 add reasoning toggle button

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:codegen": "playwright codegen http://localhost:3000",
+    "test:reasoning": "node --env-file=.env.local --import=tsx scripts/test-reasoning.ts",
     "lint": "biome check",
     "format": "biome format --write",
     "prepare": "husky",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,53 @@
+# Scripts
+
+## test-reasoning.ts
+
+Manual test script to verify all reasoning-capable models are working correctly.
+
+### Purpose
+
+- Test reasoning functionality for OpenAI, Google Gemini, and Anthropic Claude
+- Use minimal tokens (prompt: "1+1=?")
+- Run manually when needed, **not part of CI/CD**
+
+### Prerequisites
+
+**Option 1: Using AI Gateway (Recommended - tests all models)**
+```bash
+export AI_GATEWAY_API_KEY="your-ai-gateway-key"
+npm run test:reasoning
+```
+
+**Option 2: Test Google models only (no AI Gateway needed)**
+```bash
+# Ensure you have Google API key
+export GOOGLE_API_KEY="your-google-key"
+npm run test:reasoning
+```
+
+### Usage
+
+```bash
+npm run test:reasoning
+```
+
+### Features
+
+- ✅ Auto-discovers all reasoning-capable models
+- ✅ Uses "low" budget level (minimal cost)
+- ✅ Shows test results, duration, and token usage per model
+- ✅ Provides detailed summary report
+
+### Test History
+
+**2025-10-06** (zxzinn): All 15 models passed ✅
+
+### Notes
+
+- Requires appropriate API keys in environment variables
+- Will incur minimal API costs (typically < $0.10)
+- Recommended to run after major updates or periodically (e.g., monthly)
+
+#### Model Exclusions
+
+**o3-pro**: Not included as it requires Responses API and Tier 1-3 access with organization verification. Vercel AI Gateway doesn't currently support this model.

--- a/scripts/test-reasoning.ts
+++ b/scripts/test-reasoning.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env tsx
+
+/**
+ * Manual Reasoning Test Script
+ *
+ * Usage: npx tsx scripts/test-reasoning.ts
+ *
+ * Tests all models with reasoning capability using minimal tokens.
+ * Only runs when manually executed - not part of CI/CD.
+ *
+ * Requirements:
+ * - Set AI_GATEWAY_API_KEY environment variable
+ * - Or install individual provider SDKs (@ai-sdk/openai, @ai-sdk/anthropic)
+ */
+
+import { google } from "@ai-sdk/google";
+import { generateText } from "ai";
+import { getAllModels } from "../src/lib/providers/loader";
+import { getReasoningConfig } from "../src/lib/reasoning-support";
+
+// Check for AI Gateway configuration
+const hasAIGateway =
+  !!process.env.AI_GATEWAY_API_KEY || !!process.env.VERCEL_OIDC_TOKEN;
+
+// Only Google SDK is installed, others require AI Gateway
+const PROVIDER_SDK_MAP: Record<string, any> = {
+  google,
+};
+
+const TEST_PROMPT = "1+1=?";
+
+interface TestResult {
+  modelId: string;
+  success: boolean;
+  error?: string;
+  tokens?: {
+    prompt: number | undefined;
+    completion: number | undefined;
+    reasoning?: number;
+  };
+  duration?: number;
+}
+
+async function testModel(modelId: string): Promise<TestResult> {
+  const startTime = Date.now();
+
+  try {
+    const allModels = getAllModels();
+    const reasoningConfig = getReasoningConfig(modelId, allModels, true, "low");
+
+    if (!reasoningConfig) {
+      return {
+        modelId,
+        success: false,
+        error: "No reasoning support",
+      };
+    }
+
+    // Extract provider name
+    const [providerName, modelName] = modelId.split("/");
+
+    // Check if we can test this model
+    if (!hasAIGateway && !PROVIDER_SDK_MAP[providerName]) {
+      return {
+        modelId,
+        success: false,
+        error: `Skipped: No AI Gateway and ${providerName} SDK not installed`,
+      };
+    }
+
+    // Use AI Gateway (string ID) or provider SDK
+    const model = hasAIGateway
+      ? modelId
+      : PROVIDER_SDK_MAP[providerName](modelName);
+
+    const result = await generateText({
+      model,
+      prompt: TEST_PROMPT,
+      providerOptions: reasoningConfig,
+    });
+
+    const duration = Date.now() - startTime;
+
+    return {
+      modelId,
+      success: true,
+      tokens: {
+        prompt: result.usage.inputTokens,
+        completion: result.usage.outputTokens,
+        reasoning: (result.usage as any).reasoningTokens,
+      },
+      duration,
+    };
+  } catch (error) {
+    const duration = Date.now() - startTime;
+    return {
+      modelId,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+      duration,
+    };
+  }
+}
+
+async function main() {
+  console.log("🧪 Reasoning Test Script");
+  console.log("========================\n");
+
+  if (!hasAIGateway) {
+    console.log("⚠️  AI Gateway not configured");
+    console.log("   Only Google models will be tested");
+    console.log(
+      "   To test all models, set AI_GATEWAY_API_KEY environment variable\n",
+    );
+  }
+
+  console.log(`Test prompt: "${TEST_PROMPT}"`);
+  console.log(`Budget level: low\n`);
+
+  const allModels = getAllModels();
+  const reasoningModels = allModels.filter((m) => m.reasoning);
+
+  console.log(
+    `Found ${reasoningModels.length} models with reasoning support:\n`,
+  );
+
+  const results: TestResult[] = [];
+
+  for (const model of reasoningModels) {
+    process.stdout.write(`Testing ${model.id}... `);
+    const result = await testModel(model.id);
+    results.push(result);
+
+    if (result.success) {
+      console.log(`✅ ${result.duration}ms`);
+    } else {
+      console.log(`❌ ${result.error}`);
+    }
+  }
+
+  console.log("\n📊 Summary");
+  console.log("==========\n");
+
+  const successful = results.filter((r) => r.success);
+  const skipped = results.filter(
+    (r) => !r.success && r.error?.startsWith("Skipped"),
+  );
+  const failed = results.filter(
+    (r) => !r.success && !r.error?.startsWith("Skipped"),
+  );
+
+  console.log(`✅ Successful: ${successful.length}`);
+  console.log(`⏭️  Skipped: ${skipped.length}`);
+  console.log(`❌ Failed: ${failed.length}`);
+
+  if (successful.length > 0) {
+    const totalTokens = successful.reduce(
+      (sum, r) => sum + (r.tokens?.prompt || 0) + (r.tokens?.completion || 0),
+      0,
+    );
+    const totalDuration = successful.reduce(
+      (sum, r) => sum + (r.duration || 0),
+      0,
+    );
+    console.log(`\n💰 Total tokens used: ${totalTokens}`);
+    console.log(
+      `⏱️  Average duration: ${Math.round(totalDuration / successful.length)}ms`,
+    );
+  }
+
+  if (failed.length > 0) {
+    console.log("\n❌ Failed Models:");
+    failed.forEach((r) => {
+      console.log(`  - ${r.modelId}: ${r.error}`);
+    });
+  }
+
+  if (skipped.length > 0 && !hasAIGateway) {
+    console.log("\n💡 Tip: Set AI_GATEWAY_API_KEY to test all models");
+  }
+
+  console.log("\n✨ Test complete!");
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -53,6 +53,10 @@ const RequestBodySchema = z.object({
     .transform((arr) => Array.from(new Set(arr))),
   rag: z.boolean().optional().default(false),
   reasoning: z.boolean().optional().default(false),
+  reasoningBudget: z
+    .enum(["low", "medium", "high"])
+    .optional()
+    .default("medium"),
 });
 
 export async function POST(req: Request) {
@@ -73,8 +77,15 @@ export async function POST(req: Request) {
       );
     }
 
-    const { messages, model, webSearch, searchProviders, rag, reasoning } =
-      validation.data;
+    const {
+      messages,
+      model,
+      webSearch,
+      searchProviders,
+      rag,
+      reasoning,
+      reasoningBudget,
+    } = validation.data;
 
     // Convert UI messages to model messages
     const convertedMessages = convertToModelMessages(messages);
@@ -162,6 +173,7 @@ export async function POST(req: Request) {
       model,
       allModels,
       reasoning,
+      reasoningBudget,
     );
 
     const result = streamText({

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -50,7 +50,7 @@ const RequestBodySchema = z.object({
     .default([])
     .transform((arr) => Array.from(new Set(arr))),
   rag: z.boolean().optional().default(false),
-  reasoning: z.boolean().optional().default(true),
+  reasoning: z.boolean().optional().default(false),
 });
 
 export async function POST(req: Request) {

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -2,6 +2,7 @@
 
 import { useChat } from "@ai-sdk/react";
 import {
+  BrainIcon,
   CopyIcon,
   DatabaseIcon,
   FileUpIcon,
@@ -127,6 +128,7 @@ export default function AIElementsChatShowcase() {
   const [model, setModel] = useState<string>("openai/gpt-5-nano");
   const [searchProviders, setSearchProviders] = useState<string[]>([]);
   const [ragEnabled, setRagEnabled] = useState<boolean>(false);
+  const [reasoningEnabled, setReasoningEnabled] = useState<boolean>(false);
   const [uploading, setUploading] = useState(false);
 
   // Get current model's provider and name for display
@@ -152,6 +154,7 @@ export default function AIElementsChatShowcase() {
         webSearch: searchProviders.length > 0,
         searchProviders: searchProviders,
         rag: ragEnabled,
+        reasoning: reasoningEnabled,
       },
     });
   };
@@ -178,6 +181,7 @@ export default function AIElementsChatShowcase() {
           webSearch: searchProviders.length > 0,
           searchProviders: searchProviders,
           rag: ragEnabled,
+          reasoning: reasoningEnabled,
         },
       },
     );
@@ -494,6 +498,15 @@ export default function AIElementsChatShowcase() {
                   >
                     <DatabaseIcon size={16} />
                     <span>RAG {ragEnabled ? "ON" : "OFF"}</span>
+                  </Button>
+                  <Button
+                    variant={reasoningEnabled ? "default" : "ghost"}
+                    size="sm"
+                    className="h-8"
+                    onClick={() => setReasoningEnabled(!reasoningEnabled)}
+                  >
+                    <BrainIcon size={16} />
+                    <span>Reasoning {reasoningEnabled ? "ON" : "OFF"}</span>
                   </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/src/lib/providers/anthropic.ts
+++ b/src/lib/providers/anthropic.ts
@@ -1,19 +1,77 @@
-export const anthropicModels = [
+import type { Model } from "./types";
+
+export const anthropicModels: Model[] = [
   {
     id: "anthropic/claude-sonnet-4",
     name: "Claude Sonnet 4",
+    reasoning: {
+      type: "anthropic",
+      thinking: {
+        budgetTokens: {
+          min: 1024,
+          recommended: 16384,
+          budgetMapping: {
+            low: 4096,
+            medium: 16384,
+            high: 32768,
+          },
+        },
+      },
+    },
   },
   {
     id: "anthropic/claude-opus-4.1",
     name: "Claude Opus 4.1",
+    reasoning: {
+      type: "anthropic",
+      thinking: {
+        budgetTokens: {
+          min: 1024,
+          recommended: 16384,
+          budgetMapping: {
+            low: 4096,
+            medium: 16384,
+            high: 32768,
+          },
+        },
+      },
+    },
   },
   {
     id: "anthropic/claude-opus-4",
     name: "Claude Opus 4",
+    reasoning: {
+      type: "anthropic",
+      thinking: {
+        budgetTokens: {
+          min: 1024,
+          recommended: 16384,
+          budgetMapping: {
+            low: 4096,
+            medium: 16384,
+            high: 32768,
+          },
+        },
+      },
+    },
   },
   {
     id: "anthropic/claude-3.7-sonnet",
     name: "Claude 3.7 Sonnet",
+    reasoning: {
+      type: "anthropic",
+      thinking: {
+        budgetTokens: {
+          min: 1024,
+          recommended: 16384,
+          budgetMapping: {
+            low: 4096,
+            medium: 16384,
+            high: 32768,
+          },
+        },
+      },
+    },
   },
   {
     id: "anthropic/claude-3-5-sonnet",

--- a/src/lib/providers/google.ts
+++ b/src/lib/providers/google.ts
@@ -1,15 +1,65 @@
-export const googleModels = [
+import type { Model } from "./types";
+
+export const googleModels: Model[] = [
   {
     id: "google/gemini-2.5-flash",
     name: "Gemini 2.5 Flash",
+    reasoning: {
+      type: "google",
+      thinkingConfig: {
+        thinkingBudget: {
+          min: 0,
+          max: 24576,
+          default: -1,
+          budgetMapping: {
+            low: 4096,
+            medium: 8192,
+            high: 16384,
+          },
+        },
+        includeThoughts: { supported: true, default: true },
+      },
+    },
   },
   {
     id: "google/gemini-2.5-pro",
     name: "Gemini 2.5 Pro",
+    reasoning: {
+      type: "google",
+      thinkingConfig: {
+        thinkingBudget: {
+          min: 128,
+          max: 32768,
+          default: -1,
+          budgetMapping: {
+            low: 4096,
+            medium: 8192,
+            high: 16384,
+          },
+        },
+        includeThoughts: { supported: true, default: true },
+      },
+    },
   },
   {
     id: "google/gemini-2.5-flash-lite",
     name: "Gemini 2.5 Flash Lite",
+    reasoning: {
+      type: "google",
+      thinkingConfig: {
+        thinkingBudget: {
+          min: 0,
+          max: 24576,
+          default: 0,
+          budgetMapping: {
+            low: 4096,
+            medium: 8192,
+            high: 16384,
+          },
+        },
+        includeThoughts: { supported: true, default: false },
+      },
+    },
   },
   {
     id: "google/gemini-2.5-flash-preview-09-2025",

--- a/src/lib/providers/loader.ts
+++ b/src/lib/providers/loader.ts
@@ -48,3 +48,11 @@ export function getDefaultModelId(): string {
   const firstProvider = providers.find((p) => p.models.length > 0);
   return firstProvider?.models[0]?.id || "";
 }
+
+/**
+ * Gets a flat list of all models from all providers
+ */
+export function getAllModels() {
+  const providers = loadAllProviders();
+  return providers.flatMap((provider) => provider.models);
+}

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -1,19 +1,65 @@
-export const openaiModels = [
+import type { Model } from "./types";
+
+export const openaiModels: Model[] = [
   {
     id: "openai/gpt-5",
     name: "GPT-5",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["minimal", "low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/gpt-5-nano",
     name: "GPT-5 Nano",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["minimal", "low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/gpt-5-mini",
     name: "GPT-5 Mini",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["minimal", "low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/gpt-5-codex",
     name: "GPT-5 Codex",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/gpt-4.1",
@@ -50,22 +96,77 @@ export const openaiModels = [
   {
     id: "openai/o3",
     name: "o3",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/o3-mini",
     name: "o3 Mini",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/o3-pro",
     name: "o3 Pro",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/o4-mini",
     name: "o4 Mini",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/o1",
     name: "o1",
+    reasoning: {
+      type: "openai",
+      reasoningEffort: {
+        supported: ["low", "medium", "high"],
+        default: "medium",
+      },
+      reasoningSummary: {
+        supported: ["auto", "detailed"],
+        default: "detailed",
+      },
+    },
   },
   {
     id: "openai/o1-mini",

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -9,6 +9,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["minimal", "low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -24,6 +29,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["minimal", "low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -39,6 +49,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["minimal", "low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -54,6 +69,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -101,6 +121,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -116,6 +141,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -131,6 +161,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -146,6 +181,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],
@@ -161,6 +201,11 @@ export const openaiModels: Model[] = [
       reasoningEffort: {
         supported: ["low", "medium", "high"],
         default: "medium",
+        budgetMapping: {
+          low: "low",
+          medium: "medium",
+          high: "high",
+        },
       },
       reasoningSummary: {
         supported: ["auto", "detailed"],

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -56,12 +56,20 @@ export const openaiModels = [
     name: "o3 Mini",
   },
   {
+    id: "openai/o3-pro",
+    name: "o3 Pro",
+  },
+  {
     id: "openai/o4-mini",
     name: "o4 Mini",
   },
   {
     id: "openai/o1",
     name: "o1",
+  },
+  {
+    id: "openai/o1-mini",
+    name: "o1 Mini",
   },
   {
     id: "openai/gpt-oss-120b",

--- a/src/lib/providers/openai.ts
+++ b/src/lib/providers/openai.ts
@@ -154,26 +154,6 @@ export const openaiModels: Model[] = [
     },
   },
   {
-    id: "openai/o3-pro",
-    name: "o3 Pro",
-    reasoning: {
-      type: "openai",
-      reasoningEffort: {
-        supported: ["low", "medium", "high"],
-        default: "medium",
-        budgetMapping: {
-          low: "low",
-          medium: "medium",
-          high: "high",
-        },
-      },
-      reasoningSummary: {
-        supported: ["auto", "detailed"],
-        default: "detailed",
-      },
-    },
-  },
-  {
     id: "openai/o4-mini",
     name: "o4 Mini",
     reasoning: {

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,8 +1,15 @@
+export type ReasoningBudgetLevel = "low" | "medium" | "high";
+
 export interface OpenAIReasoning {
   type: "openai";
   reasoningEffort: {
     supported: ("minimal" | "low" | "medium" | "high")[];
     default: "minimal" | "low" | "medium" | "high";
+    budgetMapping: {
+      low: "low";
+      medium: "medium";
+      high: "high";
+    };
   };
   reasoningSummary: {
     supported: ("auto" | "detailed")[];
@@ -13,12 +20,39 @@ export interface OpenAIReasoning {
 export interface GoogleReasoning {
   type: "google";
   thinkingConfig: {
-    thinkingBudget: { min: number; max: number; default: number };
+    thinkingBudget: {
+      min: number;
+      max: number;
+      default: number;
+      budgetMapping: {
+        low: number;
+        medium: number;
+        high: number;
+      };
+    };
     includeThoughts: { supported: boolean; default: boolean };
   };
 }
 
-export type ReasoningCapability = OpenAIReasoning | GoogleReasoning;
+export interface AnthropicReasoning {
+  type: "anthropic";
+  thinking: {
+    budgetTokens: {
+      min: number;
+      recommended: number;
+      budgetMapping: {
+        low: number;
+        medium: number;
+        high: number;
+      };
+    };
+  };
+}
+
+export type ReasoningCapability =
+  | OpenAIReasoning
+  | GoogleReasoning
+  | AnthropicReasoning;
 
 export interface Model {
   id: string;

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,6 +1,29 @@
+export interface OpenAIReasoning {
+  type: "openai";
+  reasoningEffort: {
+    supported: ("minimal" | "low" | "medium" | "high")[];
+    default: "minimal" | "low" | "medium" | "high";
+  };
+  reasoningSummary: {
+    supported: ("auto" | "detailed")[];
+    default: "auto" | "detailed";
+  };
+}
+
+export interface GoogleReasoning {
+  type: "google";
+  thinkingConfig: {
+    thinkingBudget: { min: number; max: number; default: number };
+    includeThoughts: { supported: boolean; default: boolean };
+  };
+}
+
+export type ReasoningCapability = OpenAIReasoning | GoogleReasoning;
+
 export interface Model {
   id: string;
   name: string;
+  reasoning?: ReasoningCapability;
 }
 
 export interface Provider {

--- a/src/lib/reasoning-support.ts
+++ b/src/lib/reasoning-support.ts
@@ -1,0 +1,64 @@
+import type { Model, ReasoningCapability } from "./providers/types";
+
+export function getProviderFromModelId(modelId: string): string {
+  return modelId.split("/")[0];
+}
+
+export function getReasoningConfig(
+  modelId: string,
+  allModels: Model[],
+  enabled: boolean,
+):
+  | {
+      openai: {
+        reasoningEffort: "minimal" | "low" | "medium" | "high";
+        reasoningSummary: "auto" | "detailed";
+      };
+    }
+  | {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: number;
+          includeThoughts: boolean;
+        };
+      };
+    }
+  | undefined {
+  if (!enabled) return undefined;
+
+  const modelConfig = allModels.find((m) => m.id === modelId);
+  if (!modelConfig?.reasoning) return undefined;
+
+  const provider = getProviderFromModelId(modelId);
+
+  switch (modelConfig.reasoning.type) {
+    case "openai":
+      if (provider === "openai") {
+        return {
+          openai: {
+            reasoningEffort: modelConfig.reasoning.reasoningEffort.default,
+            reasoningSummary: modelConfig.reasoning.reasoningSummary.default,
+          },
+        };
+      }
+      return undefined;
+
+    case "google":
+      if (provider === "google" || provider === "vertex") {
+        return {
+          google: {
+            thinkingConfig: {
+              thinkingBudget:
+                modelConfig.reasoning.thinkingConfig.thinkingBudget.default,
+              includeThoughts:
+                modelConfig.reasoning.thinkingConfig.includeThoughts.default,
+            },
+          },
+        };
+      }
+      return undefined;
+
+    default:
+      return undefined;
+  }
+}

--- a/src/lib/reasoning-support.ts
+++ b/src/lib/reasoning-support.ts
@@ -46,52 +46,40 @@ export function getReasoningConfig(
 
   switch (modelConfig.reasoning.type) {
     case "openai":
-      if (provider === "openai") {
-        return {
-          openai: {
-            reasoningEffort:
-              modelConfig.reasoning.reasoningEffort.budgetMapping[budgetLevel],
-            reasoningSummary: modelConfig.reasoning.reasoningSummary.default,
-          },
-        };
-      }
-      return undefined;
+      return {
+        openai: {
+          reasoningEffort:
+            modelConfig.reasoning.reasoningEffort.budgetMapping[budgetLevel],
+          reasoningSummary: modelConfig.reasoning.reasoningSummary.default,
+        },
+      };
 
     case "google":
-      if (provider === "google" || provider === "vertex") {
-        return {
-          google: {
-            thinkingConfig: {
-              thinkingBudget:
-                modelConfig.reasoning.thinkingConfig.thinkingBudget
-                  .budgetMapping[budgetLevel],
-              includeThoughts:
-                modelConfig.reasoning.thinkingConfig.includeThoughts.default,
-            },
+      return {
+        google: {
+          thinkingConfig: {
+            thinkingBudget:
+              modelConfig.reasoning.thinkingConfig.thinkingBudget.budgetMapping[
+                budgetLevel
+              ],
+            includeThoughts:
+              modelConfig.reasoning.thinkingConfig.includeThoughts.default,
           },
-        };
-      }
-      return undefined;
+        },
+      };
 
     case "anthropic":
-      if (
-        provider === "anthropic" ||
-        provider === "vertex" ||
-        provider === "bedrock"
-      ) {
-        return {
-          anthropic: {
-            thinking: {
-              type: "enabled",
-              budgetTokens:
-                modelConfig.reasoning.thinking.budgetTokens.budgetMapping[
-                  budgetLevel
-                ],
-            },
+      return {
+        anthropic: {
+          thinking: {
+            type: "enabled",
+            budgetTokens:
+              modelConfig.reasoning.thinking.budgetTokens.budgetMapping[
+                budgetLevel
+              ],
           },
-        };
-      }
-      return undefined;
+        },
+      };
 
     default:
       return undefined;

--- a/src/lib/reasoning-support.ts
+++ b/src/lib/reasoning-support.ts
@@ -42,8 +42,6 @@ export function getReasoningConfig(
   const modelConfig = allModels.find((m) => m.id === modelId);
   if (!modelConfig?.reasoning) return undefined;
 
-  const provider = getProviderFromModelId(modelId);
-
   switch (modelConfig.reasoning.type) {
     case "openai":
       return {


### PR DESCRIPTION
## Principles Reminder

- **KISS (Keep It Simple Stupid)**: Avoid unnecessary complexity
- No meaningless comments or descriptions
- No unnecessary abstractions
- Keep code direct and clear
- **LLM Tool Resilience**: Tools designed for LLM use should return error messages rather than fail completely, allowing the LLM to handle and recover from errors gracefully

## Summary

Brief description of what this PR does.

## Changes

- [ ] List your changes here
- [ ] No debug print statements left in code (console.log, print, etc.)

## Testing

How to verify the changes work correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a chat UI reasoning toggle and unified per-model reasoning configuration (optional budget), plus a manual reasoning test script.
> 
> - **Frontend (Chat UI)**:
>   - Add `Reasoning` toggle button (Brain icon) on `src/app/chat/page.tsx`; includes flag in submit/regenerate requests.
> - **API**:
>   - Update `src/app/api/chat/route.ts` to accept `reasoning` (default false) and `reasoningBudget` (`low|medium|high`).
>   - Use `getAllModels` and `getReasoningConfig` to set `providerOptions` dynamically for reasoning.
> - **Providers/Lib**:
>   - Add per-model reasoning capabilities to `openai`, `google`, `anthropic` models (`src/lib/providers/*.ts`) via new `Model.reasoning` schema.
>   - Introduce `src/lib/providers/types.ts` with reasoning types and `ReasoningBudgetLevel`.
>   - Add `getAllModels()` in `src/lib/providers/loader.ts`.
>   - New `src/lib/reasoning-support.ts` to compute provider-specific reasoning options from model + budget.
> - **Scripts/Docs**:
>   - Add `scripts/test-reasoning.ts` and `scripts/README.md` for manual reasoning verification.
>   - Add `test:reasoning` npm script in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35155016cb12fd15a68a778846260821fdf85401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Reasoning toggle (Brain icon) in chat that applies to new messages and regenerations.
  - Added selectable reasoning budget levels (low, medium, high) with sensible defaults; reasoning is off by default.
  - Many models now expose per-model reasoning options so the toggle affects provider behavior.

- **Refactor**
  - Unified reasoning configuration so provider-specific behavior is applied consistently across requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->